### PR TITLE
fix: remove unused forward ref

### DIFF
--- a/packages/saphyra/react/src/waterfall/index.tsx
+++ b/packages/saphyra/react/src/waterfall/index.tsx
@@ -555,7 +555,7 @@ type BarProps = {
   seeingElement: string | null
 }
 
-export const Bar = forwardRef(function Bar({
+export function Bar({
   barId,
   hover,
   seeingElement,
@@ -675,7 +675,7 @@ export const Bar = forwardRef(function Bar({
       </div>
     </div>
   )
-})
+}
 
 type LineProps = {
   idx: number


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## What I did

I checked the /saphyra/packages/saphyra/react/src/waterfall/index.tsx file, and I found a component using the forwardRef without using the ref argument. So I removed the forwardRef wrapper.

Closes #9 